### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gsoft-inc/internal-developer-platform
+* @workleap/internal-developer-platform

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow-jira:
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
     with:
       branch_name: ${{ github.head_ref }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
 
   linearb:
     needs: [main]
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
     secrets: inherit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,4 +12,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gsoft-inc/internal-developer-platform
+* @workleap/internal-developer-platform

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An opinionated library that provides base unit test and fixture classes based on the `Microsoft.Extensions.*` packages used by modern .NET applications.
 
 [![nuget](https://img.shields.io/nuget/v/Workleap.Extensions.Xunit.svg?logo=nuget)](https://www.nuget.org/packages/Workleap.Extensions.Xunit/)
-[![build](https://img.shields.io/github/actions/workflow/status/gsoft-inc/wl-extensions-xunit/publish.yml?logo=github)](https://github.com/workleap/wl-extensions-xunit/actions/workflows/publish.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/workleap/wl-extensions-xunit/publish.yml?logo=github)](https://github.com/workleap/wl-extensions-xunit/actions/workflows/publish.yml)
 
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An opinionated library that provides base unit test and fixture classes based on the `Microsoft.Extensions.*` packages used by modern .NET applications.
 
 [![nuget](https://img.shields.io/nuget/v/Workleap.Extensions.Xunit.svg?logo=nuget)](https://www.nuget.org/packages/Workleap.Extensions.Xunit/)
-[![build](https://img.shields.io/github/actions/workflow/status/gsoft-inc/wl-extensions-xunit/publish.yml?logo=github)](https://github.com/gsoft-inc/wl-extensions-xunit/actions/workflows/publish.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/gsoft-inc/wl-extensions-xunit/publish.yml?logo=github)](https://github.com/workleap/wl-extensions-xunit/actions/workflows/publish.yml)
 
 
 ## Getting started
@@ -84,8 +84,8 @@ public class MyUnitFixture : BaseUnitFixture
 
 ## Contribute
 
-Please see [CONTRIBUTING](https://github.com/gsoft-inc/wl-extensions-xunit/blob/main/CONTRIBUTING.md)
+Please see [CONTRIBUTING](https://github.com/workleap/wl-extensions-xunit/blob/main/CONTRIBUTING.md)
 
 ## License
 
-Copyright © 2022, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE.
+Copyright © 2022, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Security Policy
 
-If you'd like to report a vulnerability, please open a [GitHub issue](https://github.com/gsoft-inc/wl-extensions-xunit/issues).
+If you'd like to report a vulnerability, please open a [GitHub issue](https://github.com/workleap/wl-extensions-xunit/issues).

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>gsoft-inc/renovate-config",
-    "github>gsoft-inc/renovate-config:all-automerge.json"
+    "github>workleap/renovate-config",
+    "github>workleap/renovate-config:all-automerge.json"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 